### PR TITLE
Make repos public again

### DIFF
--- a/terraform_git_repo/main.tf
+++ b/terraform_git_repo/main.tf
@@ -9,7 +9,7 @@ data "github_repositories" "repos" {
 resource "github_repository" "repo" {
   name      = var.repo_name
   auto_init = true
-  private   = true
+  private   = false # We can't have private repos and configure branch protection etc. without a paid for account.
 
   # Only if the repository already exists can we set the default branch
   default_branch = contains(data.github_repositories.repos.names, var.repo_name) ? "main" : null


### PR DESCRIPTION
We can't have private repos and configure branch protection etc. without
a paid for account.